### PR TITLE
Incorrect output on HTML element

### DIFF
--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -1,0 +1,4 @@
+{
+  "/dist/app.js": "/dist/app.js",
+  "/style.css": "/style.css"
+}

--- a/templates/partials/header.blade.php
+++ b/templates/partials/header.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html {{ language_attributes() }}">
+<html {{ language_attributes() }}>
 <head>
     <meta charset="{{ get_bloginfo( 'charset' ) }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/templates/partials/header.blade.php
+++ b/templates/partials/header.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html {{ get_language_attributes() }}">
+<html {{ language_attributes() }}">
 <head>
     <meta charset="{{ get_bloginfo( 'charset' ) }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,12 +1,14 @@
-let mix = require('laravel-mix');
-let purgecss = require('@fullhuman/postcss-purgecss')
+let mix = require("laravel-mix");
+let purgecss = require("@fullhuman/postcss-purgecss");
 
-mix.js(`src/scripts/app.js`, 'dist/')
-    .postCss(`src/styles/style.css`, './', [
-        require('tailwindcss'),
-        ...process.env.NODE_ENV === 'production'
-            ? [purgecss({
-                content: ['**/*.php', '**/*.html'],
-                defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || []
-            })] : []
-    ])
+mix.js(`src/scripts/app.js`, "dist/").postCss(`src/styles/style.css`, "./", [
+  require("tailwindcss"),
+  ...(process.env.NODE_ENV === "production"
+    ? [
+        purgecss({
+          content: ["**/*.php", "**/*.html"],
+          defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || [],
+        }),
+      ]
+    : []),
+]);


### PR DESCRIPTION
The HTML element is outputting as `<html lang="&quot;en-US&quot;">`.

This is caused by:

- There is a stray quote at https://github.com/lukeraymonddowning/MountainBreeze/blob/b8a37968e16ce7452ed051ace975a8240705f6f0/templates/partials/header.blade.php#L2
- Use of `get_language_attributes()` rather than `language_attributes()`.

Removing the stray quote and changing the function fixes the issue.